### PR TITLE
correct check for ABI-L2-CMIP

### DIFF
--- a/goespy/Downloader.py
+++ b/goespy/Downloader.py
@@ -59,7 +59,7 @@ def ABI_Downloader(home, bucket, year, month, day, hour, product, channel):
                             
                             filename = obj.key.rsplit('/', 1)[1]
 
-                            if ( (prod[:-1] == "ABI-L1b-Rad") or (prod[-1] == "ABI-L2-CMIP") ):
+                            if ( (prod[:-1] == "ABI-L1b-Rad") or (prod[:-1] == "ABI-L2-CMIP") ):
                                 for ch in channel:
                                     ## when the filename has the same Channel from the user channel variable
                                     ## call the function from download, but before it's done somes check files and directory


### PR DESCRIPTION
a colon before the `-1` was missing and hence couldn't check correctly for the "ABI-L2-CMIP" product. So, it skipped the step and downloaded all channels, instead of the specified channel. Now it should work :)